### PR TITLE
Fixes "Undefined constant STDOUT" error

### DIFF
--- a/src/Cli.php
+++ b/src/Cli.php
@@ -146,6 +146,11 @@ class Cli
             return true;
         }
 
+        // fix for "Undefined constant STDOUT" error
+        if (!\defined('STDOUT')) {
+            return false;
+        }
+        
         $stream = STDOUT;
         if (\DIRECTORY_SEPARATOR === '\\') {
             return (\function_exists('sapi_windows_vt100_support')


### PR DESCRIPTION
I've hit a bug when trying to run some of the git commands - it could be related to Windows setup on which I've tested the library.

The fix covers only this one specific error, I'm not sure if there aren't any more which could be fixed in similar way. At least this one works for me.